### PR TITLE
feat(ui): remove progress bars from gallery pages

### DIFF
--- a/src/components/NewTestamentGallery.tsx
+++ b/src/components/NewTestamentGallery.tsx
@@ -32,18 +32,7 @@ export const NewTestamentGallery = ({ stories }: NewTestamentGalleryProps) => {
         </div>
       </header>
 
-      {/* Progress Bar */}
-      <div className="bg-white shadow-sm">
-        <div className="container mx-auto px-6 py-4">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-600">Your Progress</span>
-            <span className="text-biblical-blue font-semibold">0 of {stories.length} stories completed</span>
-          </div>
-          <div className="w-full bg-gray-200 rounded-full h-2 mt-2">
-            <div className="bg-biblical-blue h-2 rounded-full" style="width: 0%"></div>
-          </div>
-        </div>
-      </div>
+
 
       {/* Coming Soon Notice */}
       <section className="py-8 bg-blue-50">

--- a/src/components/OldTestamentGallery.tsx
+++ b/src/components/OldTestamentGallery.tsx
@@ -32,18 +32,7 @@ export const OldTestamentGallery = ({ stories }: OldTestamentGalleryProps) => {
         </div>
       </header>
 
-      {/* Progress Bar */}
-      <div className="bg-white shadow-sm">
-        <div className="container mx-auto px-6 py-4">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-600">Your Progress</span>
-            <span className="text-biblical-gold font-semibold">0 of {stories.length} stories completed</span>
-          </div>
-          <div className="w-full bg-gray-200 rounded-full h-2 mt-2">
-            <div className="bg-biblical-gold h-2 rounded-full" style="width: 0%"></div>
-          </div>
-        </div>
-      </div>
+
 
       {/* Stories Grid */}
       <section className="py-12 bg-gradient-to-b from-white to-amber-50">


### PR DESCRIPTION
- Remove 'Your progress' section from Old Testament gallery page
- Remove 'Your progress' section from New Testament gallery page
- Improve page layout by eliminating unused progress tracking UI
- Enhance user experience with cleaner, less cluttered gallery interfaces
- Maintain all existing functionality while simplifying visual design

This change creates a more focused browsing experience for users exploring the biblical art collections.